### PR TITLE
Add preview deployTarget for per-PR Ember app builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = {
       'dev',
       'devindex',
       'qa',
-      'prod'
+      'prod',
+      'preview'
     ];
     var ENV = {};
     ENV.build = {};
@@ -81,10 +82,38 @@ module.exports = {
       herokuAppName = 'yapp-cedar';
     }
 
-    if (deployTarget === 'qa' || deployTarget === 'prod') {
+    if (deployTarget === 'preview') {
+      if (!process.env.PR_NUMBER) {
+        throw new Error('PR_NUMBER env var is required for preview deploys');
+      }
+      if (!process.env.PREVIEW_SHA) {
+        throw new Error('PREVIEW_SHA env var is required for preview deploys');
+      }
+      ENV.s3.bucket = 'yapp-assets';
+      ENV.redis.url = process.env.REDIS_URL; // optional, falls back to reading from heroku below
+      // Pin the revision to the PR HEAD SHA so Rails finds it at <prefix>:index:<sha>.
+      // Without this the redis plugin generates its own random revisionKey, which
+      // would have to be threaded back to the preview:pr-<N> hash; using the SHA
+      // keeps the contract simple.
+      ENV.redis.revisionKey = process.env.PREVIEW_SHA;
+      // Skip activation: previews must not bump <prefix>:index:current. Reviewers
+      // reach them via the preview:pr-<N> hash, written by CI after deploy.
+      domain = "pr-" + process.env.PR_NUMBER + ".preview.yappqa.us";
+      herokuAppName = 'qa-yapp-cedar';
+    }
+
+    if (deployTarget === 'qa' || deployTarget === 'prod' || deployTarget === 'preview') {
       ENV.build.environment = 'production';
       ENV.s3.accessKeyId = process.env.YAPP_AWS_KEY;
       ENV.s3.secretAccessKey = process.env.YAPP_AWS_SECRET;
+      ENV.redis.redisOptions = {
+        tls: {
+          rejectUnauthorized: false
+        }
+      };
+    }
+
+    if (deployTarget === 'qa' || deployTarget === 'prod') {
       ENV.slack.didDeploy = function(context) {
         return function(slack){
           var message;
@@ -107,11 +136,6 @@ module.exports = {
           };
         }
       };
-      ENV.redis.redisOptions = {
-        tls: {
-          rejectUnauthorized: false
-        }
-      };
       ENV.redis.didDeployMessage = function(context) {
         if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionKey) {
           var revisionKey = context.revisionData.revisionKey;
@@ -124,8 +148,17 @@ module.exports = {
       };
     }
 
+    if (deployTarget === 'preview') {
+      ENV.redis.didDeployMessage = function(context) {
+        var revisionKey = context.revisionData.revisionKey;
+        return "Preview deployed for PR #" + process.env.PR_NUMBER + " (revision: " + revisionKey + ").\n"
+             + "URL: https://" + domain + "/" + prefix + "/\n"
+             + "Note: CI must HSET preview:pr-" + process.env.PR_NUMBER + " " + prefix + " " + revisionKey + " for routing to take effect.";
+      };
+    }
+
     return RSVP.resolve().then(function(){
-      if (deployTarget === 'qa' || deployTarget === 'prod') {
+      if (deployTarget === 'qa' || deployTarget === 'prod' || deployTarget === 'preview') {
         if (!ENV.redis.url || ENV.redis.url === '') {
           return new RSVP.Promise(function(resolve, reject){
             if (process.env.HEROKU_PLATFORM_API_TOKEN) {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ module.exports = {
       ENV.redis.revisionKey = process.env.PREVIEW_SHA;
       // Skip activation: previews must not bump <prefix>:index:current. Reviewers
       // reach them via the preview:pr-<N> hash, written by CI after deploy.
+      ENV.pipeline.activateOnDeploy = false;
       domain = "pr-" + process.env.PR_NUMBER + ".preview.yappqa.us";
       herokuAppName = 'qa-yapp-cedar';
     }


### PR DESCRIPTION
## Background and Goal

Adds a `preview` deployTarget to `getConfiguration`, enabling per-PR preview deploys for Yapp's desktop Ember apps. This is the plugin-side piece of the cross-repo [PR Preview Deployments project](https://linear.app/yapp/project/pr-preview-deployments-for-desktop-ember-apps-125862dd0b0a) (Linear Y-1330) — consumed by monotonic's CircleCI workflow once released.

## Where to start

- `index.js` — `'preview'` is now a valid deployTarget. The block reads `PR_NUMBER` and `PREVIEW_SHA` from env (both required) and configures S3 + Redis like QA but without activation.

## Key decisions and non-obvious mechanics

- **`ENV.redis.revisionKey = process.env.PREVIEW_SHA`** pins the revision to the PR HEAD SHA. The redis plugin will store the HTML at `<prefix>:index:<sha>` — that's where the Rails-side `Ember::Deploy.fetch_revision(prefix, sha)` looks it up.
- **No `activateOnDeploy`**, so `<prefix>:index:current` is never updated. The active QA build is untouched. Reviewers land on the preview build via a separate `preview:pr-<N>` hash that the CI deploy job writes after the plugin's deploy completes (out of scope for this PR — handled in monotonic's CI changes).
- **Same S3 prefix as QA (`<prefix>`)**, not a per-PR subdirectory. Assets are SHA-fingerprinted, so multiple PR builds + the active QA build coexist without collision. The tradeoff is that S3 cleanup on PR close requires a separate sweep (planned as a follow-up in the project plan); not deleting them is acceptable since storage is cheap.
- **Slack hooks are skipped for previews** — the QA/prod Slack `didDeploy` would otherwise post "deployed but did not activate" messages on every PR push, which is too noisy. Reviewers get a GitHub commit status from CI instead.
- **`didDeployMessage` is overridden for previews** to print a useful local message (preview URL + HSET reminder) so an engineer running the deploy locally can see what just happened.

## Release / consumer coordination

After this PR merges and a new version is released (release-it picks `enhancement` label up automatically), monotonic's CircleCI ticket (Y-1331) bumps the dep and wires up the preview workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)