### PR TITLE
Y-1331 Let file-hash generate preview revisionKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,16 +86,12 @@ module.exports = {
       if (!process.env.PR_NUMBER) {
         throw new Error('PR_NUMBER env var is required for preview deploys');
       }
-      if (!process.env.PREVIEW_SHA) {
-        throw new Error('PREVIEW_SHA env var is required for preview deploys');
-      }
       ENV.s3.bucket = 'yapp-assets';
       ENV.redis.url = process.env.REDIS_URL; // optional, falls back to reading from heroku below
-      // Pin the revision to the PR HEAD SHA so Rails finds it at <prefix>:index:<sha>.
-      // Without this the redis plugin generates its own random revisionKey, which
-      // would have to be threaded back to the preview:pr-<N> hash; using the SHA
-      // keeps the contract simple.
-      ENV.redis.revisionKey = process.env.PREVIEW_SHA;
+      // revisionKey is left to the default file-hash data generator, which
+      // computes md5(dist/index.html). This matches QA's shape (32-hex md5)
+      // so Rails' manifest_id regex accepts it. CI is responsible for
+      // mirroring the same md5 into preview:pr-<N> after deploy.
       // Skip activation: previews must not bump <prefix>:index:current. Reviewers
       // reach them via the preview:pr-<N> hash, written by CI after deploy.
       ENV.pipeline.activateOnDeploy = false;


### PR DESCRIPTION
## Background and Goal

Follow-up to #19. The previous override pinned `ENV.redis.revisionKey` to the 40-char git SHA from `PREVIEW_SHA`, but `yapp-server`'s `Ember::Deploy.fetch_revision` enforces `/\A(dev|test|[0-9a-f]{32})\Z/i` — 32 hex only — so every preview lookup would raise `"Manifest ID '...' was invalid"`.

Dropping the override lets the default `file-hash` data generator (from `ember-cli-deploy-revision-data`) compute `md5(dist/index.html)`, which matches QA's manifest_id shape (32-hex md5) and passes the regex unchanged. CI in `monotonic` mirrors the same md5 into the `preview:pr-<N>` routing hash after deploy completes.

## Key decisions

- `PREVIEW_SHA` env var is no longer required and is removed from the validation block. The git SHA is still available to the consumer (CI) via `CIRCLE_SHA1` if it wants to tag deploys, but the plugin doesn't need it.
- `PR_NUMBER` is still required — it drives the S3 prefix and the preview hostname.
- No change to `qa` / `prod` deployTargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)